### PR TITLE
Improve CLI ergonomics

### DIFF
--- a/README
+++ b/README
@@ -12,13 +12,25 @@ QUICK START
 -----------
 
   # Terminal 1: start the server
-  python3 main.py serve
+  ./cleanplate serve
 
   # Terminal 2: run client commands
-  python3 main.py --help
-  python3 main.py register --username alice
-  python3 main.py login    --username alice
-  python3 main.py whoami
+  ./cleanplate --help
+  ./cleanplate register --username alice
+  ./cleanplate login    --username alice
+  ./cleanplate whoami
+
+If the script is executable, you can also put the repo on your `PATH` and run
+`cleanplate ...` directly.
+
+Friendlier shortcuts are also supported, for example:
+`./cleanplate signup alice`
+`./cleanplate login alice`
+`./cleanplate passwd alice`
+`./cleanplate me`
+`./cleanplate create-household "Maple House"`
+`./cleanplate create-chore 1 "Take out trash"`
+`./cleanplate complete 4`
 
 By default the client connects to http://127.0.0.1:8000.
 To use a different server, set CLEANPLATE_SERVER_URL.
@@ -28,71 +40,82 @@ FULL COMMAND REFERENCE
 ----------------------
 
 -- Identity & Access (Person 1) --
-  python3 main.py register   --username <name>
-  python3 main.py login      --username <name>
-  python3 main.py reset-password --username <name>
-  python3 main.py logout
-  python3 main.py whoami
+  ./cleanplate register   --username <name>
+  ./cleanplate signup     <name>
+  ./cleanplate login      --username <name>
+  ./cleanplate login      <name>
+  ./cleanplate reset-password --username <name>
+  ./cleanplate passwd     <name>
+  ./cleanplate logout
+  ./cleanplate whoami
+  ./cleanplate me
 
 -- Household Management (Person 2) --
-  python3 main.py household create        --name "42 Elm St"
-  python3 main.py household join          --code <invite_code>
-  python3 main.py household show          --id <household_id>
-  python3 main.py household list
-  python3 main.py household rotate-invite --id <household_id>
-  python3 main.py household remove-member --id <household_id> --username bob
+  ./cleanplate household create        --name "42 Elm St"
+  ./cleanplate house create            "42 Elm St"
+  ./cleanplate create-household        "42 Elm St"
+  ./cleanplate household join          --code <invite_code>
+  ./cleanplate join-household          <invite_code>
+  ./cleanplate household show          --id <household_id>
+  ./cleanplate household list
+  ./cleanplate household rotate-invite --id <household_id>
+  ./cleanplate household remove-member --id <household_id> --username bob
 
 -- Chore Management (Person 3) --
-  python3 main.py chore create  --household <id> --title "Take out trash" [--due YYYY-MM-DD] [--assign bob]
-  python3 main.py chore assign  --chore <id> --username bob
-  python3 main.py chore list    --household <id> [--status pending|complete|disputed] [--mine]
-  python3 main.py chore show    --chore <id>
+  ./cleanplate chore create  --household <id> --title "Take out trash" [--due YYYY-MM-DD] [--assign bob]
+  ./cleanplate create-chore  <id> "Take out trash" [--due YYYY-MM-DD] [--assign bob]
+  ./cleanplate chore assign  --chore <id> --username bob
+  ./cleanplate chore list    --household <id> [--status pending|complete|disputed] [--mine]
+  ./cleanplate chore show    --chore <id>
 
 -- Activity & Completion (Person 4) --
-  python3 main.py activity complete --chore <id>
-  python3 main.py activity dispute  --chore <id> --reason "Floor still dirty"
-  python3 main.py activity resolve  --complaint <id> --outcome uphold|dismiss --note "..."
-  python3 main.py activity audit    --household <id>
-  python3 main.py activity poll
+  ./cleanplate activity complete --chore <id>
+  ./cleanplate complete          <id>
+  ./cleanplate activity dispute  --chore <id> --reason "Floor still dirty"
+  ./cleanplate activity resolve  --complaint <id> --outcome uphold|dismiss --note "..."
+  ./cleanplate activity audit    --household <id>
+  ./cleanplate audit             <household_id>
+  ./cleanplate activity poll
 
 
 EXAMPLE WALKTHROUGH
 -------------------
 
   # Two users register
-  python3 main.py register --username alice
-  python3 main.py register --username bob
+  ./cleanplate register --username alice
+  ./cleanplate register --username bob
 
   # Alice logs in and creates a household
-  python3 main.py login --username alice
-  python3 main.py household create --name "42 Elm Street"
+  ./cleanplate login --username alice
+  ./cleanplate household create --name "42 Elm Street"
   # → prints invite code, e.g. "Invite code: aB3xQr_kLmN"
 
   # Bob logs in and joins
-  python3 main.py login --username bob
-  python3 main.py household join --code aB3xQr_kLmN
+  ./cleanplate login --username bob
+  ./cleanplate household join --code aB3xQr_kLmN
 
   # Alice (admin) creates and assigns a chore
-  python3 main.py login --username alice
-  python3 main.py chore create --household 1 --title "Vacuum living room" --assign bob --due 2025-04-10
+  ./cleanplate login --username alice
+  ./cleanplate chore create --household 1 --title "Vacuum living room" --assign bob --due 2025-04-10
 
   # Bob completes the chore
-  python3 main.py login --username bob
-  python3 main.py activity complete --chore 1
+  ./cleanplate login --username bob
+  ./cleanplate activity complete --chore 1
 
   # Alice disputes it
-  python3 main.py login --username alice
-  python3 main.py activity dispute --chore 1 --reason "Missed under the couch"
+  ./cleanplate login --username alice
+  ./cleanplate activity dispute --chore 1 --reason "Missed under the couch"
 
   # Alice resolves her own dispute (uphold = bob must redo it)
-  python3 main.py activity resolve --complaint 1 --outcome uphold --note "Please redo"
+  ./cleanplate activity resolve --complaint 1 --outcome uphold --note "Please redo"
 
   # Anyone can view the audit log
-  python3 main.py activity audit --household 1
+  ./cleanplate activity audit --household 1
 
 
 FILE LAYOUT
 -----------
+  cleanplate      Shell wrapper for running the CLI
   main.py         Client entry point + server launcher
   client_cli.py   Client-side argparse handlers and HTTP calls
   api_client.py   JSON/HTTP client helper

--- a/cleanplate
+++ b/cleanplate
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/main.py" "$@"

--- a/client_cli.py
+++ b/client_cli.py
@@ -11,6 +11,15 @@ from api_client import ClientError, get_server_url, invoke
 from session import clear_session, load_session, require_session, save_session
 
 
+def _arg(args, primary: str, fallback: str | None = None):
+    value = getattr(args, primary, None)
+    if value is not None:
+        return value
+    if fallback is not None:
+        return getattr(args, fallback, None)
+    return None
+
+
 def _print_output(output: str) -> None:
     if output:
         print(output, end="" if output.endswith("\n") else "\n")
@@ -38,7 +47,7 @@ def _server_session() -> dict:
 
 
 def cmd_register(args) -> None:
-    username = (args.username or input("Username: ").strip()).strip()
+    username = (_arg(args, "username", "username_pos") or input("Username: ").strip()).strip()
     password = getpass.getpass("Password (min 8 chars): ")
     confirm_password = getpass.getpass("Confirm password: ")
 
@@ -59,7 +68,7 @@ def cmd_register(args) -> None:
 
 
 def cmd_login(args) -> None:
-    username = (args.username or input("Username: ").strip()).strip()
+    username = (_arg(args, "username", "username_pos") or input("Username: ").strip()).strip()
     password = getpass.getpass("Password: ")
 
     try:
@@ -75,7 +84,7 @@ def cmd_login(args) -> None:
 
 
 def cmd_reset_password(args) -> None:
-    username = (args.username or input("Username: ").strip()).strip()
+    username = (_arg(args, "username", "username_pos") or input("Username: ").strip()).strip()
     current_password = getpass.getpass("Current password: ")
     new_password = getpass.getpass("New password (min 8 chars): ")
     confirm_password = getpass.getpass("Confirm new password: ")
@@ -124,25 +133,29 @@ def _remote_command(action: str, payload: dict) -> None:
 
 
 def cmd_create_household(args) -> None:
-    name = args.name or input("Household name: ").strip()
+    name = _arg(args, "name", "name_pos") or input("Household name: ").strip()
     _remote_command("household.create", {"name": name})
 
 
 def cmd_join_household(args) -> None:
-    code = args.code or input("Invite code: ").strip()
+    code = _arg(args, "code", "code_pos") or input("Invite code: ").strip()
     _remote_command("household.join", {"code": code})
 
 
 def cmd_show_household(args) -> None:
-    _remote_command("household.show", {"id": args.id})
+    household_id = _arg(args, "id", "id_pos")
+    _remote_command("household.show", {"id": household_id})
 
 
 def cmd_rotate_invite(args) -> None:
-    _remote_command("household.rotate-invite", {"id": args.id})
+    household_id = _arg(args, "id", "id_pos")
+    _remote_command("household.rotate-invite", {"id": household_id})
 
 
 def cmd_remove_member(args) -> None:
-    _remote_command("household.remove-member", {"id": args.id, "username": args.username})
+    household_id = _arg(args, "id", "id_pos")
+    username = _arg(args, "username", "username_pos")
+    _remote_command("household.remove-member", {"id": household_id, "username": username})
 
 
 def cmd_list_households(args) -> None:
@@ -150,11 +163,12 @@ def cmd_list_households(args) -> None:
 
 
 def cmd_create_chore(args) -> None:
-    title = args.title or input("Chore title: ").strip()
+    household_id = _arg(args, "household", "household_pos")
+    title = _arg(args, "title", "title_pos") or input("Chore title: ").strip()
     _remote_command(
         "chore.create",
         {
-            "household": args.household,
+            "household": household_id,
             "title": title,
             "description": args.description,
             "due": args.due,
@@ -164,14 +178,17 @@ def cmd_create_chore(args) -> None:
 
 
 def cmd_assign_chore(args) -> None:
-    _remote_command("chore.assign", {"chore": args.chore, "username": args.username})
+    chore_id = _arg(args, "chore", "chore_pos")
+    username = _arg(args, "username", "username_pos")
+    _remote_command("chore.assign", {"chore": chore_id, "username": username})
 
 
 def cmd_list_chores(args) -> None:
+    household_id = _arg(args, "household", "household_pos")
     _remote_command(
         "chore.list",
         {
-            "household": args.household,
+            "household": household_id,
             "status": args.status,
             "mine": args.mine,
             "overdue": args.overdue,
@@ -180,28 +197,33 @@ def cmd_list_chores(args) -> None:
 
 
 def cmd_show_chore(args) -> None:
-    _remote_command("chore.show", {"chore": args.chore})
+    chore_id = _arg(args, "chore", "chore_pos")
+    _remote_command("chore.show", {"chore": chore_id})
 
 
 def cmd_complete(args) -> None:
-    _remote_command("activity.complete", {"chore": args.chore})
+    chore_id = _arg(args, "chore", "chore_pos")
+    _remote_command("activity.complete", {"chore": chore_id})
 
 
 def cmd_dispute(args) -> None:
+    chore_id = _arg(args, "chore", "chore_pos")
     reason = args.reason or input("Reason for dispute: ").strip()
-    _remote_command("activity.dispute", {"chore": args.chore, "reason": reason})
+    _remote_command("activity.dispute", {"chore": chore_id, "reason": reason})
 
 
 def cmd_resolve(args) -> None:
+    complaint_id = _arg(args, "complaint", "complaint_pos")
     note = args.note or input("Resolution note: ").strip()
     _remote_command(
         "activity.resolve",
-        {"complaint": args.complaint, "outcome": args.outcome, "note": note},
+        {"complaint": complaint_id, "outcome": args.outcome, "note": note},
     )
 
 
 def cmd_audit(args) -> None:
-    _remote_command("activity.audit", {"household": args.household})
+    household_id = _arg(args, "household", "household_pos")
+    _remote_command("activity.audit", {"household": household_id})
 
 
 def cmd_poll(args) -> None:
@@ -209,99 +231,162 @@ def cmd_poll(args) -> None:
 
 
 def register_subparsers(subparsers) -> None:
-    p = subparsers.add_parser("register", help="Create a new user account")
-    p.add_argument("--username", default=None, help="Desired username")
+    p = subparsers.add_parser("register", aliases=["signup", "sign-up"], help="Create a new user account")
+    p.add_argument("username_pos", nargs="?", help="Desired username")
+    p.add_argument("--username", dest="username", default=None, help="Desired username")
+    p.set_defaults(username=None)
     p.set_defaults(func=cmd_register)
 
     p = subparsers.add_parser("login", help=f"Log in via server at {get_server_url()}")
-    p.add_argument("--username", default=None, help="Your username")
+    p.add_argument("username_pos", nargs="?", help="Your username")
+    p.add_argument("--username", dest="username", default=None, help="Your username")
+    p.set_defaults(username=None)
     p.set_defaults(func=cmd_login)
 
-    p = subparsers.add_parser("reset-password", help=f"Change your password via server at {get_server_url()}")
-    p.add_argument("--username", default=None, help="Your username")
+    p = subparsers.add_parser(
+        "reset-password",
+        aliases=["passwd", "password"],
+        help=f"Change your password via server at {get_server_url()}",
+    )
+    p.add_argument("username_pos", nargs="?", help="Your username")
+    p.add_argument("--username", dest="username", default=None, help="Your username")
+    p.set_defaults(username=None)
     p.set_defaults(func=cmd_reset_password)
 
     p = subparsers.add_parser("logout", help="Log out locally")
     p.set_defaults(func=cmd_logout)
 
-    p = subparsers.add_parser("whoami", help="Show who is currently logged in")
+    p = subparsers.add_parser("whoami", aliases=["me"], help="Show who is currently logged in")
     p.set_defaults(func=cmd_whoami)
 
-    p = subparsers.add_parser("household", help="Household management commands")
+    p = subparsers.add_parser("household", aliases=["house"], help="Household management commands")
     sub = p.add_subparsers(dest="household_cmd", required=True)
 
-    c = sub.add_parser("create", help="Create a new household")
-    c.add_argument("--name", default=None)
+    c = sub.add_parser("create", aliases=["new"], help="Create a new household")
+    c.add_argument("name_pos", nargs="?", help="Household name")
+    c.add_argument("--name", dest="name", default=None)
+    c.set_defaults(name=None)
     c.set_defaults(func=cmd_create_household)
 
     c = sub.add_parser("join", help="Join a household via invite code")
-    c.add_argument("--code", default=None)
+    c.add_argument("code_pos", nargs="?", help="Invite code")
+    c.add_argument("--code", dest="code", default=None)
+    c.set_defaults(code=None)
     c.set_defaults(func=cmd_join_household)
 
     c = sub.add_parser("show", help="Show household info and members")
-    c.add_argument("--id", type=int, required=True, metavar="HOUSEHOLD_ID")
+    c.add_argument("id_pos", nargs="?", type=int, metavar="HOUSEHOLD_ID")
+    c.add_argument("--id", dest="id", type=int, default=None, metavar="HOUSEHOLD_ID")
+    c.set_defaults(id=None)
     c.set_defaults(func=cmd_show_household)
 
     c = sub.add_parser("list", help="List your households")
     c.set_defaults(func=cmd_list_households)
 
     c = sub.add_parser("rotate-invite", help="Generate a new invite code (admin)")
-    c.add_argument("--id", type=int, required=True, metavar="HOUSEHOLD_ID")
+    c.add_argument("id_pos", nargs="?", type=int, metavar="HOUSEHOLD_ID")
+    c.add_argument("--id", dest="id", type=int, default=None, metavar="HOUSEHOLD_ID")
+    c.set_defaults(id=None)
     c.set_defaults(func=cmd_rotate_invite)
 
     c = sub.add_parser("remove-member", help="Remove a member (admin)")
-    c.add_argument("--id", type=int, required=True, metavar="HOUSEHOLD_ID")
-    c.add_argument("--username", required=True)
+    c.add_argument("id_pos", nargs="?", type=int, metavar="HOUSEHOLD_ID")
+    c.add_argument("username_pos", nargs="?", help="Member username")
+    c.add_argument("--id", dest="id", type=int, default=None, metavar="HOUSEHOLD_ID")
+    c.add_argument("--username", dest="username", default=None)
+    c.set_defaults(id=None, username=None)
     c.set_defaults(func=cmd_remove_member)
 
     p = subparsers.add_parser("chore", help="Chore management commands")
     sub = p.add_subparsers(dest="chore_cmd", required=True)
 
-    c = sub.add_parser("create", help="Create a chore (admin only)")
-    c.add_argument("--household", type=int, required=True, metavar="HOUSEHOLD_ID")
-    c.add_argument("--title", default=None)
+    c = sub.add_parser("create", aliases=["new"], help="Create a chore (admin only)")
+    c.add_argument("household_pos", nargs="?", type=int, metavar="HOUSEHOLD_ID")
+    c.add_argument("title_pos", nargs="?", help="Chore title")
+    c.add_argument("--household", dest="household", type=int, default=None, metavar="HOUSEHOLD_ID")
+    c.add_argument("--title", dest="title", default=None)
     c.add_argument("--description", default="")
     c.add_argument("--due", default=None, metavar="YYYY-MM-DD")
     c.add_argument("--assign", default=None, metavar="USERNAME")
+    c.set_defaults(household=None, title=None)
     c.set_defaults(func=cmd_create_chore)
 
     c = sub.add_parser("assign", help="Assign a chore to a member (admin only)")
-    c.add_argument("--chore", type=int, required=True, metavar="CHORE_ID")
-    c.add_argument("--username", required=True)
+    c.add_argument("chore_pos", nargs="?", type=int, metavar="CHORE_ID")
+    c.add_argument("username_pos", nargs="?", help="Assignee username")
+    c.add_argument("--chore", dest="chore", type=int, default=None, metavar="CHORE_ID")
+    c.add_argument("--username", dest="username", default=None)
+    c.set_defaults(chore=None, username=None)
     c.set_defaults(func=cmd_assign_chore)
 
     c = sub.add_parser("list", help="List chores in a household")
-    c.add_argument("--household", type=int, required=True, metavar="HOUSEHOLD_ID")
+    c.add_argument("household_pos", nargs="?", type=int, metavar="HOUSEHOLD_ID")
+    c.add_argument("--household", dest="household", type=int, default=None, metavar="HOUSEHOLD_ID")
     c.add_argument("--status", default=None, choices=["pending", "complete", "disputed"])
     c.add_argument("--mine", action="store_true", help="Only show chores assigned to you")
     c.add_argument("--overdue", action="store_true", help="Show overdue chores")
+    c.set_defaults(household=None)
     c.set_defaults(func=cmd_list_chores)
 
     c = sub.add_parser("show", help="Show full details of a chore")
-    c.add_argument("--chore", type=int, required=True, metavar="CHORE_ID")
+    c.add_argument("chore_pos", nargs="?", type=int, metavar="CHORE_ID")
+    c.add_argument("--chore", dest="chore", type=int, default=None, metavar="CHORE_ID")
+    c.set_defaults(chore=None)
     c.set_defaults(func=cmd_show_chore)
 
     p = subparsers.add_parser("activity", help="Completion, disputes, and audit log")
     sub = p.add_subparsers(dest="activity_cmd", required=True)
 
     c = sub.add_parser("complete", help="Mark a chore as complete")
-    c.add_argument("--chore", type=int, required=True, metavar="CHORE_ID")
+    c.add_argument("chore_pos", nargs="?", type=int, metavar="CHORE_ID")
+    c.add_argument("--chore", dest="chore", type=int, default=None, metavar="CHORE_ID")
+    c.set_defaults(chore=None)
     c.set_defaults(func=cmd_complete)
 
     c = sub.add_parser("dispute", help="Dispute a completed chore")
-    c.add_argument("--chore", type=int, required=True, metavar="CHORE_ID")
+    c.add_argument("chore_pos", nargs="?", type=int, metavar="CHORE_ID")
+    c.add_argument("--chore", dest="chore", type=int, default=None, metavar="CHORE_ID")
     c.add_argument("--reason", default=None)
+    c.set_defaults(chore=None)
     c.set_defaults(func=cmd_dispute)
 
     c = sub.add_parser("resolve", help="Resolve a complaint (admin only)")
-    c.add_argument("--complaint", type=int, required=True, metavar="COMPLAINT_ID")
+    c.add_argument("complaint_pos", nargs="?", type=int, metavar="COMPLAINT_ID")
+    c.add_argument("--complaint", dest="complaint", type=int, default=None, metavar="COMPLAINT_ID")
     c.add_argument("--outcome", required=True, choices=["uphold", "dismiss"])
     c.add_argument("--note", default=None)
+    c.set_defaults(complaint=None)
     c.set_defaults(func=cmd_resolve)
 
     c = sub.add_parser("audit", help="View audit log for a household")
-    c.add_argument("--household", type=int, required=True, metavar="HOUSEHOLD_ID")
+    c.add_argument("household_pos", nargs="?", type=int, metavar="HOUSEHOLD_ID")
+    c.add_argument("--household", dest="household", type=int, default=None, metavar="HOUSEHOLD_ID")
+    c.set_defaults(household=None)
     c.set_defaults(func=cmd_audit)
 
     c = sub.add_parser("poll", help="View unread notifications")
     c.set_defaults(func=cmd_poll)
+
+    p = subparsers.add_parser("create-household", help="Create a household with a flat command")
+    p.add_argument("name", nargs="?", help="Household name")
+    p.set_defaults(func=cmd_create_household)
+
+    p = subparsers.add_parser("join-household", help="Join a household with a flat command")
+    p.add_argument("code", nargs="?", help="Invite code")
+    p.set_defaults(func=cmd_join_household)
+
+    p = subparsers.add_parser("create-chore", help="Create a chore with a flat command")
+    p.add_argument("household", type=int, metavar="HOUSEHOLD_ID")
+    p.add_argument("title", nargs="?", help="Chore title")
+    p.add_argument("--description", default="")
+    p.add_argument("--due", default=None, metavar="YYYY-MM-DD")
+    p.add_argument("--assign", default=None, metavar="USERNAME")
+    p.set_defaults(func=cmd_create_chore)
+
+    p = subparsers.add_parser("complete", help="Complete a chore with a flat command")
+    p.add_argument("chore", type=int, metavar="CHORE_ID")
+    p.set_defaults(func=cmd_complete)
+
+    p = subparsers.add_parser("audit", help="Audit a household with a flat command")
+    p.add_argument("household", type=int, metavar="HOUSEHOLD_ID")
+    p.set_defaults(func=cmd_audit)

--- a/tests.py
+++ b/tests.py
@@ -892,12 +892,36 @@ class TestMainParser(cleanplateTestCase):
         self.assertEqual(args.username, "alice")
         self.assertTrue(callable(args.func))
 
+    def test_build_parser_parses_login_with_positional_username(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["login", "alice"])
+
+        self.assertEqual(args.command, "login")
+        self.assertEqual(args.username_pos, "alice")
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_signup_alias(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["signup", "alice"])
+
+        self.assertEqual(args.command, "signup")
+        self.assertEqual(args.username_pos, "alice")
+        self.assertTrue(callable(args.func))
+
     def test_build_parser_parses_reset_password_command(self):
         parser = main.build_parser()
         args = parser.parse_args(["reset-password", "--username", "alice"])
 
         self.assertEqual(args.command, "reset-password")
         self.assertEqual(args.username, "alice")
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_passwd_alias(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["passwd", "alice"])
+
+        self.assertEqual(args.command, "passwd")
+        self.assertEqual(args.username_pos, "alice")
         self.assertTrue(callable(args.func))
 
     def test_build_parser_parses_nested_household_command(self):
@@ -909,6 +933,32 @@ class TestMainParser(cleanplateTestCase):
         self.assertEqual(args.name, "Demo")
         self.assertTrue(callable(args.func))
 
+    def test_build_parser_parses_house_alias_and_positional_name(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["house", "create", "Demo"])
+
+        self.assertEqual(args.command, "house")
+        self.assertEqual(args.household_cmd, "create")
+        self.assertEqual(args.name_pos, "Demo")
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_flat_create_household_command(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["create-household", "Demo"])
+
+        self.assertEqual(args.command, "create-household")
+        self.assertEqual(args.name, "Demo")
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_flat_create_chore_command(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["create-chore", "3", "Take out trash"])
+
+        self.assertEqual(args.command, "create-chore")
+        self.assertEqual(args.household, 3)
+        self.assertEqual(args.title, "Take out trash")
+        self.assertTrue(callable(args.func))
+
     def test_build_parser_parses_nested_activity_command(self):
         parser = main.build_parser()
         args = parser.parse_args(["activity", "complete", "--chore", "4"])
@@ -916,6 +966,21 @@ class TestMainParser(cleanplateTestCase):
         self.assertEqual(args.command, "activity")
         self.assertEqual(args.activity_cmd, "complete")
         self.assertEqual(args.chore, 4)
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_flat_complete_command(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["complete", "4"])
+
+        self.assertEqual(args.command, "complete")
+        self.assertEqual(args.chore, 4)
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_me_alias(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["me"])
+
+        self.assertEqual(args.command, "me")
         self.assertTrue(callable(args.func))
 
 


### PR DESCRIPTION
I staged the CLI wrapper and command-polish changes, committed them as Improve CLI ergonomics, and pushed shell-scripting to GitHub. You can open the PR here: https://github.com/d-koding/CleanPlate/pull/new/shell-scripting

Suggested PR summary: adds a cleanplate shell wrapper, supports friendlier aliases like signup, passwd, and me, adds flatter commands like create-household, create-chore, and complete, and updates parser tests plus README examples to match.