### PR TITLE
Add interactive CLI shell

### DIFF
--- a/README
+++ b/README
@@ -14,16 +14,42 @@ QUICK START
   # Terminal 1: start the server
   ./cleanplate serve
 
-  # Terminal 2: run client commands
-  ./cleanplate --help
-  ./cleanplate register --username alice
-  ./cleanplate login    --username alice
-  ./cleanplate whoami
+  # Terminal 2: open the interactive shell
+  ./cleanplate interactive
+  cleanplate> signup alice
+  cleanplate> login alice
+  cleanplate> create-household "42 Elm Street"
+  cleanplate> household list
+  cleanplate> exit
 
 If the script is executable, you can also put the repo on your `PATH` and run
 `cleanplate ...` directly.
 
-Friendlier shortcuts are also supported, for example:
+PRIMARY USAGE
+-------------
+
+The intended way to use CleanPlate is as one continuous command session:
+
+  ./cleanplate interactive
+
+Inside the session, type regular commands without restarting the app each time:
+
+  cleanplate> signup alice
+  cleanplate> login alice
+  cleanplate> me
+  cleanplate> create-household "Maple House"
+  cleanplate> create-chore 1 "Take out trash"
+  cleanplate> complete 4
+  cleanplate> help
+  cleanplate> exit
+
+`shell` and `repl` are aliases for `interactive`.
+
+ONE-SHOT MODE
+-------------
+
+You can still run single commands directly from your shell when needed:
+
 `./cleanplate signup alice`
 `./cleanplate login alice`
 `./cleanplate passwd alice`
@@ -38,6 +64,8 @@ To use a different server, set CLEANPLATE_SERVER_URL.
 
 FULL COMMAND REFERENCE
 ----------------------
+
+These commands work both inside `./cleanplate interactive` and as direct shell commands.
 
 -- Identity & Access (Person 1) --
   ./cleanplate register   --username <name>
@@ -81,40 +109,44 @@ FULL COMMAND REFERENCE
 EXAMPLE WALKTHROUGH
 -------------------
 
+  # Start one continuous command session
+  ./cleanplate interactive
+
   # Two users register
-  ./cleanplate register --username alice
-  ./cleanplate register --username bob
+  cleanplate> signup alice
+  cleanplate> signup bob
 
   # Alice logs in and creates a household
-  ./cleanplate login --username alice
-  ./cleanplate household create --name "42 Elm Street"
+  cleanplate> login alice
+  cleanplate> create-household "42 Elm Street"
   # → prints invite code, e.g. "Invite code: aB3xQr_kLmN"
 
   # Bob logs in and joins
-  ./cleanplate login --username bob
-  ./cleanplate household join --code aB3xQr_kLmN
+  cleanplate> login bob
+  cleanplate> join-household aB3xQr_kLmN
 
   # Bob can also join or create additional households later
-  python3 main.py household create --name "Weekend Cabin"
-  python3 main.py household list
+  cleanplate> create-household "Weekend Cabin"
+  cleanplate> household list
 
   # Alice (admin) creates and assigns a chore
-  ./cleanplate login --username alice
-  ./cleanplate chore create --household 1 --title "Vacuum living room" --assign bob --due 2025-04-10
+  cleanplate> login alice
+  cleanplate> create-chore 1 "Vacuum living room" --assign bob --due 2025-04-10
 
   # Bob completes the chore
-  ./cleanplate login --username bob
-  ./cleanplate activity complete --chore 1
+  cleanplate> login bob
+  cleanplate> complete 1
 
   # Alice disputes it
-  ./cleanplate login --username alice
-  ./cleanplate activity dispute --chore 1 --reason "Missed under the couch"
+  cleanplate> login alice
+  cleanplate> activity dispute --chore 1 --reason "Missed under the couch"
 
   # Alice resolves her own dispute (uphold = bob must redo it)
-  ./cleanplate activity resolve --complaint 1 --outcome uphold --note "Please redo"
+  cleanplate> activity resolve --complaint 1 --outcome uphold --note "Please redo"
 
   # Anyone can view the audit log
-  ./cleanplate activity audit --household 1
+  cleanplate> audit 1
+  cleanplate> exit
 
 
 FILE LAYOUT

--- a/main.py
+++ b/main.py
@@ -3,9 +3,61 @@ main.py — cleanplate client CLI and server launcher.
 """
 
 import argparse
+import contextlib
+import io
+import shlex
 
 from api_server import run_server
 import client_cli
+
+
+def _interactive_help() -> None:
+    print("Interactive CleanPlate shell")
+    print("Type a command like: login alice")
+    print("Type 'help' to show CLI help, or 'exit' to quit.")
+
+
+def _run_interactive_shell(parser: argparse.ArgumentParser) -> None:
+    _interactive_help()
+
+    while True:
+        try:
+            line = input("cleanplate> ").strip()
+        except EOFError:
+            print()
+            break
+        except KeyboardInterrupt:
+            print()
+            continue
+
+        if not line:
+            continue
+        if line.lower() in {"exit", "quit"}:
+            break
+        if line.lower() == "help":
+            parser.print_help()
+            continue
+
+        try:
+            argv = shlex.split(line)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            continue
+
+        try:
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                args = parser.parse_args(argv)
+            args.func(args)
+        except SystemExit:
+            error_output = stderr.getvalue().strip() if "stderr" in locals() else ""
+            if error_output:
+                print(error_output)
+            # Keep the shell alive after command validation or handler failures.
+            continue
+        except KeyboardInterrupt:
+            print()
+            continue
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -19,6 +71,13 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--host", default="127.0.0.1")
     serve.add_argument("--port", type=int, default=8000)
     serve.set_defaults(func=lambda args: run_server(args.host, args.port))
+
+    shell = subparsers.add_parser(
+        "interactive",
+        aliases=["shell", "repl"],
+        help="Start an interactive CleanPlate command session",
+    )
+    shell.set_defaults(func=lambda args, parser=parser: _run_interactive_shell(parser))
 
     client_cli.register_subparsers(subparsers)
 

--- a/tests.py
+++ b/tests.py
@@ -252,7 +252,7 @@ class TestAuth(cleanplateTestCase):
 
     def test_whoami_lists_all_households_for_user(self):
         self.create_user("alice", "GoodPass!123")
-        alice = db.query_one("SELECT id FROM users WHERE username = ?", ("alice",))
+        alice = auth._find_user_by_username("alice")
         first = db.execute(
             "INSERT INTO households (name, invite_code) VALUES (?, ?)",
             ("Maple House", "invite-one"),
@@ -1036,6 +1036,54 @@ class TestMainParser(cleanplateTestCase):
 
         self.assertEqual(args.command, "me")
         self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_interactive_command(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["interactive"])
+
+        self.assertEqual(args.command, "interactive")
+        self.assertTrue(callable(args.func))
+
+    def test_build_parser_parses_shell_alias(self):
+        parser = main.build_parser()
+        args = parser.parse_args(["shell"])
+
+        self.assertEqual(args.command, "shell")
+        self.assertTrue(callable(args.func))
+
+
+class TestInteractiveShell(cleanplateTestCase):
+    def test_interactive_shell_dispatches_commands_until_exit(self):
+        parser = main.build_parser()
+        called = []
+
+        def fake_login(args):
+            called.append(("login", args.username_pos))
+
+        parser._subparsers._group_actions[0].choices["login"].set_defaults(func=fake_login)
+
+        with patch("builtins.input", side_effect=["login alice", "exit"]):
+            out = self.capture_output(main._run_interactive_shell, parser)
+
+        self.assertIn("Interactive CleanPlate shell", out)
+        self.assertEqual(called, [("login", "alice")])
+
+    def test_interactive_shell_shows_parser_help(self):
+        parser = main.build_parser()
+
+        with patch("builtins.input", side_effect=["help", "exit"]):
+            out = self.capture_output(main._run_interactive_shell, parser)
+
+        self.assertIn("usage: cleanplate", out)
+
+    def test_interactive_shell_handles_parse_error_and_continues(self):
+        parser = main.build_parser()
+
+        with patch("builtins.input", side_effect=["not-a-command", "exit"]):
+            out = self.capture_output(main._run_interactive_shell, parser)
+
+        self.assertIn("invalid choice", out)
+        self.assertIn("Interactive CleanPlate shell", out)
 
 
 class TestClientServerArchitecture(cleanplateTestCase):


### PR DESCRIPTION
Adds an interactive cleanplate shell as the primary CLI workflow, keeps the one-shot commands available, updates README to document the continuous-session experience, and adds parser/session tests for interactive mode.

The deleted SQLite sidecar files were left out of the commit, so they won’t pollute the PR.